### PR TITLE
Ignore Test Bot .ini file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Test Bot
+bender.ini
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Git should ignore any bender.ini files used for testing