### PR TITLE
Split Long Responses in Two and Improve Logging

### DIFF
--- a/.github/workflows/flake8-pytest.yml
+++ b/.github/workflows/flake8-pytest.yml
@@ -33,7 +33,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --max-complexity=10 --statistics
+        flake8 . --count --max-complexity=20 --statistics --max-line-length=99
     - name: Test with pytest
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ The bot will log in to Discord and start listening for messages in the configure
 The script accepts the following command line arguments:
 
 - `-d` or `--daemon`: Runs the bot in daemon mode with no output to the terminal.
-- `-b` or `--background`: Runs the bot in background mode with output redirected to `nohup.out`.
 - `-c` or `--config`: Allows the use of a custom configuration file. The next argument should be the path to the configuration file.
 - `-f` or `--folder`: Allows the use of a base folder. The next argument should be the path to the base folder.
 

--- a/discordian.sh
+++ b/discordian.sh
@@ -32,11 +32,6 @@ while [[ "$#" -gt 0 ]]; do
             output="/dev/null"
             log "Running in daemon mode. Output redirected to $output"
             ;;
-        -b|--background)
-            # Background mode: Output to nohup.out
-            output="nohup.out"
-            log "Running in background mode. Output redirected to $output"
-            ;;
         -c|--config)
             # Custom configuration file: Ensure argument is provided
             if [[ -n "$2" && ! "$2" =~ ^- ]]; then
@@ -88,7 +83,7 @@ if [[ -z $output ]]; then
     # Normal execution
     eval "$command"
 else
-    # Background or daemon execution
+    # Daemon execution
     log "Running command in background: $command > $output 2>&1 &"
     if ! ($command > "$output" 2>&1 &); then
         log "Error: Failed to execute command."


### PR DESCRIPTION
This fixes https://github.com/rlywtf/DiscordianAI/issues/14 by splitting any response that is long into two messages from a newline closest to the middle.

While here I've improved the logging capabilities.

`Flake8`'s line length test is set to 99 overriding the default and I also bumped the complexity limit from 10 to 20.

The `on_message` function has been broken up to avoid the Flake8 complexity failures. We now have one function for DMs and another for channel messages.

The `discordian.sh` script's redundant background mode was removed.