### PR TITLE
Fix session handling

### DIFF
--- a/.github/workflows/flake8-pytest.yml
+++ b/.github/workflows/flake8-pytest.yml
@@ -33,7 +33,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --max-complexity=20 --statistics --max-line-length=99
+        flake8 . --count --max-complexity=10 --statistics --max-line-length=99
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
We need to handle session disconnects, resuming, and changes in shard states.

This fixes some of the errors we were seeing with:
 - Shard ID None WebSocket closed
 - Shard ID None heartbeat blocked for more than

This also makes a new `call_openai_api` function definition and turns the response into an async call on a thread.

The rate limit function was cleaned up while I was here.

The Flake8 complexity was reduced to its default of 10 and the main function has this check disabled now.